### PR TITLE
Update json and json_pure to 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
-.idea
-doc
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,3 @@
 source "http://rubygems.org"
 
-gem "rake"
-gem "json", "~>1.4.0"
-gem "json_pure", "~>1.4.0"
-gem "rdoc"
-
-group :test do
-  gem "rr", "~>1.0"
-end
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,33 @@
+PATH
+  remote: .
+  specs:
+    getresponse (0.6)
+      json (~> 2.1)
+      json_pure (~> 2.1)
+
 GEM
   remote: http://rubygems.org/
   specs:
-    json (1.4.6)
-    json (1.4.6-java)
-    json_pure (1.4.6)
-    rake (0.9.2.2)
-    rdoc (3.11)
-      json (~> 1.4)
-    rr (1.0.4)
+    json (2.1.0)
+    json_pure (2.1.0)
+    minitest (5.11.3)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
+    rake (10.5.0)
+    rdoc (6.0.4)
+    rr (1.2.1)
 
 PLATFORMS
-  java
   ruby
+  x86_64-linux
 
 DEPENDENCIES
-  json (~> 1.4.0)
-  json_pure (~> 1.4.0)
-  rake
+  bundler (~> 1.7)
+  getresponse!
+  minitest-line
+  rake (~> 10.0)
   rdoc
-  rr (~> 1.0)
+  rr
+
+BUNDLED WITH
+   1.16.2

--- a/getresponse.gemspec
+++ b/getresponse.gemspec
@@ -8,9 +8,14 @@ Gem::Specification.new do |s|
   s.description   = "With this gem you can manage your subscribers, campaigns, messages etc."
   s.version       = "0.6"
 
-  s.add_dependency "json", "~> 1.4"
-  s.add_dependency "json_pure", "~>1.4"
-  s.add_development_dependency "rr", "~>1.0"
+  s.add_dependency "json", '~> 2.1'
+  s.add_dependency "json_pure", '~> 2.1'
+  s.add_development_dependency "rr"
+  s.add_development_dependency "bundler", "~> 1.7"
+  s.add_development_dependency "rake", "~> 10.0"
+  s.add_development_dependency "minitest-line"
+  s.add_development_dependency "rdoc"
+
   s.required_rubygems_version = ">= 1.3.5"
 
   s.files         = Dir.glob("lib/**/*") + %w(README.rdoc)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,18 +1,13 @@
 # encoding: utf-8
-require "test/unit"
 require File.join(File.dirname(__FILE__), "../lib/get_response")
 require 'rr'
 
 # Test helper methods
+require "minitest/autorun"
 
-
-class Test::Unit::TestCase
-
-  include RR::Adapters::TestUnit
-
+Minitest::Spec.class_eval do
 
   protected
-
 
   def get_campaigns_resp
     {
@@ -34,7 +29,6 @@ class Test::Unit::TestCase
       }
     }.to_json
   end
-
 
   def get_contacts_resp
     { "result" => {

--- a/test/unit/account_test.rb
+++ b/test/unit/account_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class AccountTest < Test::Unit::TestCase
+class AccountTest < Minitest::Spec
 
   def test_initialize
     account = GetResponse::Account.new({"login" => "test", "from_name" => "From test",

--- a/test/unit/blacklist_test.rb
+++ b/test/unit/blacklist_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class GetResponse::BlacklistTest < Test::Unit::TestCase
+class GetResponse::BlacklistTest < Minitest::Spec
 
   def setup
     @ancestor = Object.new

--- a/test/unit/campaign_proxy_test.rb
+++ b/test/unit/campaign_proxy_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class GetResponse::CampaignProxyTest < Test::Unit::TestCase
+class GetResponse::CampaignProxyTest < Minitest::Spec
 
   def setup
     @connection = GetResponse::Connection.new("my_test_api_key")
@@ -40,7 +40,7 @@ class GetResponse::CampaignProxyTest < Test::Unit::TestCase
     result = @proxy.create(new_campaign_params)
 
     assert_kind_of GetResponse::Campaign, result
-    assert_not_nil result.id
+    refute_nil result.id
   end
 
 

--- a/test/unit/campaign_test.rb
+++ b/test/unit/campaign_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class GetResponse::CampaignTest < Test::Unit::TestCase
+class GetResponse::CampaignTest < Minitest::Spec
 
   def setup
     @gr_connection = GetResponse::Connection.new("my_secret_api_key")
@@ -63,13 +63,13 @@ class GetResponse::CampaignTest < Test::Unit::TestCase
     postal_address = @campaign.postal_address
 
     assert_kind_of Hash, postal_address
-    assert_not_nil postal_address["name"]
-    assert_not_nil postal_address["address"]
-    assert_not_nil postal_address["city"]
-    assert_not_nil postal_address["state"]
-    assert_not_nil postal_address["zip"]
-    assert_not_nil postal_address["country"]
-    assert_not_nil postal_address["design"]
+    refute_nil postal_address["name"]
+    refute_nil postal_address["address"]
+    refute_nil postal_address["city"]
+    refute_nil postal_address["state"]
+    refute_nil postal_address["zip"]
+    refute_nil postal_address["country"]
+    refute_nil postal_address["design"]
   end
 
 

--- a/test/unit/conditions_test.rb
+++ b/test/unit/conditions_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class GetResponse::ConfirmationSubjectProxyTest < Test::Unit::TestCase
+class GetResponse::ConfirmationSubjectProxyTest < Minitest::Spec
 
   include GetResponse::Conditions
 
@@ -50,7 +50,7 @@ class GetResponse::ConfirmationSubjectProxyTest < Test::Unit::TestCase
 
 
   def test_parse_condition_with_some_bad_operator
-    exception = assert_raise(GetResponse::GetResponseError) { parse_condition("BAD_OPERATOR", "value") }
+    exception = assert_raises(GetResponse::GetResponseError) { parse_condition("BAD_OPERATOR", "value") }
     assert_equal "Bad operator: BAD_OPERATOR", exception.message
   end
 

--- a/test/unit/confirmation_body_proxy_test.rb
+++ b/test/unit/confirmation_body_proxy_test.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class GetResponse::ConfirmationBodyProxyTest < Test::Unit::TestCase
+class GetResponse::ConfirmationBodyProxyTest < Minitest::Spec
 
   def setup
     @connection = GetResponse::Connection.new("my_test_api_key")
@@ -44,7 +44,7 @@ class GetResponse::ConfirmationBodyProxyTest < Test::Unit::TestCase
       {"result"=>{}, "error"=>nil}
     end
 
-    exception = assert_raise(GetResponse::GetResponseError) { @proxy.find("bad_id") }
+    exception = assert_raises(GetResponse::GetResponseError) { @proxy.find("bad_id") }
     assert_equal "Confirmation body with id 'bad_id' not found.", exception.message
   end
 

--- a/test/unit/confirmation_subject_proxy_test.rb
+++ b/test/unit/confirmation_subject_proxy_test.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class GetResponse::ConfirmationSubjectProxyTest < Test::Unit::TestCase
+class GetResponse::ConfirmationSubjectProxyTest < Minitest::Spec
 
   def setup
     @connection = GetResponse::Connection.new("my_test_api_key")
@@ -42,7 +42,7 @@ class GetResponse::ConfirmationSubjectProxyTest < Test::Unit::TestCase
     params = {"confirmation_subject" => "bad_id"}
     mock(@connection).send_request("get_confirmation_subject", params) { {"result" => {}, "error" => nil} }
 
-    exception = assert_raise(GetResponse::GetResponseError) { @proxy.find("bad_id") }
+    exception = assert_raises(GetResponse::GetResponseError) { @proxy.find("bad_id") }
     assert_equal "Confirmation subject with id 'bad_id' not found.", exception.message
   end
 

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -1,8 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class GetResponse::ConnectionTest < Test::Unit::TestCase
-
-  include RR::Adapters::TestUnit
+class GetResponse::ConnectionTest < Minitest::Spec
 
   def setup
     @gr_connection = GetResponse::Connection.new("my_secret_api_key")
@@ -23,7 +21,7 @@ class GetResponse::ConnectionTest < Test::Unit::TestCase
   def test_ping_with_bad_api_key
     mock(@mocked_response).code { "403" }
 
-    exception = assert_raise(GetResponse::GetResponseError) { @gr_connection.ping }
+    exception = assert_raises(GetResponse::GetResponseError) { @gr_connection.ping }
     assert_equal 'API key verification failed', exception.message
   end
 

--- a/test/unit/contact_proxy_test.rb
+++ b/test/unit/contact_proxy_test.rb
@@ -1,7 +1,7 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 require 'date'
 
-class GetResponse::ContactProxyTest < Test::Unit::TestCase
+class GetResponse::ContactProxyTest < Minitest::Spec
 
 
   def setup
@@ -48,7 +48,7 @@ class GetResponse::ContactProxyTest < Test::Unit::TestCase
     fail_exception = GetResponse::GetResponseError.new("Contact already queued for target campaign")
     mock(@connection).send_request(:add_contact, attrs_sent_to_service) { raise fail_exception }
 
-    assert_raise(GetResponse::GetResponseError) { @proxy.create(new_contact_attrs) }
+    assert_raises(GetResponse::GetResponseError) { @proxy.create(new_contact_attrs) }
   end
 
 

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -1,9 +1,9 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class ContactTest < Test::Unit::TestCase
+
+class ContactTest < Minitest::Spec
 
   include RR::Adapters::TestUnit
-
 
   def setup
     @gr_connection = GetResponse::Connection.new("my_secret_api_key")
@@ -56,7 +56,7 @@ class ContactTest < Test::Unit::TestCase
     satisfy_mocks
     contact = new_contact
 
-    exception = assert_raise(GetResponse::GetResponseError) { contact.destroy }
+    exception = assert_raises(GetResponse::GetResponseError) { contact.destroy }
     assert_equal "Can't delete contact without id", exception.message
   end
 
@@ -65,7 +65,7 @@ class ContactTest < Test::Unit::TestCase
     mock(@mocked_response).body { destroy_missing_contact_mock }
     contact =  new_contact("id" => "45bgT")
 
-    exception = assert_raise(GetResponse::GetResponseError) { contact.destroy }
+    exception = assert_raises(GetResponse::GetResponseError) { contact.destroy }
     assert_equal "Missing contact", exception.message
   end
 
@@ -83,7 +83,7 @@ class ContactTest < Test::Unit::TestCase
     mock(@mocked_response).body { add_contact_invalid_email_syntax }
     contact = new_contact("id" => "45bgT")
 
-    exception = assert_raise(GetResponse::GetResponseError) { contact.update("email" => "sebastian//host.xyz") }
+    exception = assert_raises(GetResponse::GetResponseError) { contact.update("email" => "sebastian//host.xyz") }
     assert_equal "Invalid email syntax", exception.message
   end
 
@@ -101,7 +101,7 @@ class ContactTest < Test::Unit::TestCase
     mock(@mocked_response).body { move_contact_fail }
     contact = new_contact("id" => "45bgT")
 
-    exception = assert_raise(GetResponse::GetResponseError) { contact.move("blah") }
+    exception = assert_raises(GetResponse::GetResponseError) { contact.move("blah") }
     assert_equal "Missing campaign", exception.message
   end
 
@@ -136,7 +136,7 @@ class ContactTest < Test::Unit::TestCase
     mock(@mocked_response).body { set_cycle_fail_mock }
     contact = new_contact("id" => "45bgT")
 
-    exception = assert_raise(GetResponse::GetResponseError) { contact.set_cycle("6") }
+    exception = assert_raises(GetResponse::GetResponseError) { contact.set_cycle("6") }
     assert_equal "Missing contact", exception.message
   end
 
@@ -164,7 +164,7 @@ class ContactTest < Test::Unit::TestCase
     mock(@mocked_response).body { set_contact_name_exception_response }
     contact = new_contact
 
-    exception = assert_raise(GetResponse::GetResponseError) { contact.name = "My new name" }
+    exception = assert_raises(GetResponse::GetResponseError) { contact.name = "My new name" }
     assert_equal "Missing contact", exception.message
   end
 

--- a/test/unit/domain_proxy_test.rb
+++ b/test/unit/domain_proxy_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class DomainProxyTest < Test::Unit::TestCase
+class DomainProxyTest < Minitest::Spec
 
   def setup
     @connection = GetResponse::Connection.new("API_KEY")

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class DomainTest < Test::Unit::TestCase
+class DomainTest < Minitest::Spec
 
   def test_instance
     @domain = GetResponse::Domain.new("id" => "234", "domain" => "newsletter.company.com",

--- a/test/unit/follow_up_test.rb
+++ b/test/unit/follow_up_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class GetResponse::FollowUpTest < Test::Unit::TestCase
+class GetResponse::FollowUpTest < Minitest::Spec
 
   def setup
     @connection = GetResponse::Connection.new("API_KEY")
@@ -33,8 +33,8 @@ class GetResponse::FollowUpTest < Test::Unit::TestCase
     params = {:message => @follow_up.id, :day_of_cycle => new_day_of_cycle}
     exception = GetResponse::GetResponseError.new "Day of cycle already used"
     mock(@connection).send_request("set_follow_up_cycle", params) { raise exception }
-    
-    ex = assert_raise(GetResponse::GetResponseError) { @follow_up.day_of_cycle = new_day_of_cycle }
+
+    ex = assert_raises(GetResponse::GetResponseError) { @follow_up.day_of_cycle = new_day_of_cycle }
     assert_equal "Day of cycle already used", ex.message
   end
 

--- a/test/unit/from_field_test.rb
+++ b/test/unit/from_field_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class FromFieldTest < Test::Unit::TestCase
+class FromFieldTest < Minitest::Spec
 
   def test_initialize
     @from_field = GetResponse::FromField.new("name" => "text", "email" => "test@email.cc",

--- a/test/unit/from_fields_proxy_test.rb
+++ b/test/unit/from_fields_proxy_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class FromFieldsProxyTest < Test::Unit::TestCase
+class FromFieldsProxyTest < Minitest::Spec
 
   def setup
     @connection = GetResponse::Connection.new("API_KEY")
@@ -32,7 +32,7 @@ class FromFieldsProxyTest < Test::Unit::TestCase
       raise GetResponse::GetResponseError.new(add_account_from_field_fail["error"])
     end
 
-    assert_raise(GetResponse::GetResponseError) { @proxy.create(new_from_field_attrs) }
+    assert_raises(GetResponse::GetResponseError) { @proxy.create(new_from_field_attrs) }
   end
 
 
@@ -48,7 +48,7 @@ class FromFieldsProxyTest < Test::Unit::TestCase
   def test_find_by_id_with_bad_id
     mock(@connection).send_request("get_account_from_field", {"account_from_field" => "bad_id"}) { {"result"=>{}, "error"=>nil} }
 
-    exception = assert_raise(GetResponse::GetResponseError) { @proxy.find("bad_id") }
+    exception = assert_raises(GetResponse::GetResponseError) { @proxy.find("bad_id") }
     assert_equal "Form field with id 'bad_id' not found.", exception.message
   end
 

--- a/test/unit/links_proxy_test.rb
+++ b/test/unit/links_proxy_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class GetResponse::LinksProxyTest < Test::Unit::TestCase
+class GetResponse::LinksProxyTest < Minitest::Spec
 
   def setup
     @connection = GetResponse::Connection.new("my_api_key")

--- a/test/unit/message_proxy_test.rb
+++ b/test/unit/message_proxy_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class GetResponse::MessageProxyTest < Test::Unit::TestCase
+class GetResponse::MessageProxyTest < Minitest::Spec
 
   def setup
     @connection = GetResponse::Connection.new("my_api_key")

--- a/test/unit/message_test.rb
+++ b/test/unit/message_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class GetResponse::MessageTest < Test::Unit::TestCase
+class GetResponse::MessageTest < Minitest::Spec
 
   def setup
     @connection = GetResponse::Connection.new("my_api_key")

--- a/test/unit/newsletter_test.rb
+++ b/test/unit/newsletter_test.rb
@@ -1,6 +1,6 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '../test_helper'))
+require 'test_helper'
 
-class GetResponse::NewsletterTest < Test::Unit::TestCase
+class GetResponse::NewsletterTest < Minitest::Spec
 
   def setup
     @connection = GetResponse::Connection.new("API_KEY")


### PR DESCRIPTION
This will allow to install `constantcontact` 4.x in mothership which is required to upgrade rails to 5.x

All those changes are required to have the tests passing...otherwise the test won't even start....