### PR TITLE
adding code to pass along the HTTP_PROXY info to HTTP.start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.ruby-version

--- a/lib/get_response/contact.rb
+++ b/lib/get_response/contact.rb
@@ -19,6 +19,7 @@ module GetResponse
       @reason = params["reason"]
       @connection = connection
       @duplicated = false
+      @lazy_save = false
     end
 
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,9 @@
 # encoding: utf-8
 require File.join(File.dirname(__FILE__), "../lib/get_response")
-require 'rr'
 
 # Test helper methods
 require "minitest/autorun"
+require 'rr'
 
 Minitest::Spec.class_eval do
 

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -3,10 +3,21 @@ require 'test_helper'
 class GetResponse::ConnectionTest < Minitest::Spec
 
   def setup
+    ENV['HTTP_PROXY'] = nil
     @gr_connection = GetResponse::Connection.new("my_secret_api_key")
     @mocked_response = mock
     mock(@mocked_response).code.any_times { 200 }
     mock(Net::HTTP).start("api2.getresponse.com", 80, nil, nil).any_times { @mocked_response }
+  end
+
+  def test_ping_with_http_proxy_enabled
+    ENV['HTTP_PROXY'] = "http://1.1.1.1:123"
+    mock(Net::HTTP).start("api2.getresponse.com", 80, '1.1.1.1', 123).any_times { @mocked_response }
+
+    mock(@mocked_response).body { "{\"error\":null,\"result\":{\"ping\":\"pong\"}}" }
+
+    response = @gr_connection.ping
+    assert_equal true, response
   end
 
 

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -6,7 +6,7 @@ class GetResponse::ConnectionTest < Minitest::Spec
     @gr_connection = GetResponse::Connection.new("my_secret_api_key")
     @mocked_response = mock
     mock(@mocked_response).code.any_times { 200 }
-    mock(Net::HTTP).start("api2.getresponse.com", 80).any_times { @mocked_response }
+    mock(Net::HTTP).start("api2.getresponse.com", 80, nil, nil).any_times { @mocked_response }
   end
 
 

--- a/test/unit/contact_test.rb
+++ b/test/unit/contact_test.rb
@@ -1,15 +1,12 @@
 require 'test_helper'
 
-
 class ContactTest < Minitest::Spec
-
-  include RR::Adapters::TestUnit
 
   def setup
     @gr_connection = GetResponse::Connection.new("my_secret_api_key")
     @mocked_response = mock
     mock(@mocked_response).code.any_times { 200 }
-    mock(Net::HTTP).start("api2.getresponse.com", 80).any_times { @mocked_response }
+    mock(Net::HTTP).start("api2.getresponse.com", 80, nil, nil).any_times { @mocked_response }
   end
 
 
@@ -255,7 +252,7 @@ class ContactTest < Minitest::Spec
 
 
   def satisfy_mocks
-    Net::HTTP.start("api2.getresponse.com", 80)
+    Net::HTTP.start("api2.getresponse.com", 80, nil, nil)
   end
 
 


### PR DESCRIPTION
Adding in code to use the HTTP_PROXY ENV var if its available

https://www.pivotaltracker.com/story/show/173061067

## Test Results
```
# Running:

..../Users/dmonsewicz/dev/ruby-getresponse/lib/get_response/contact.rb:118: warning: method redefined; discarding old customs
/Users/dmonsewicz/dev/ruby-getresponse/lib/get_response/contact.rb:127: warning: method redefined; discarding old customs=
/Users/dmonsewicz/dev/ruby-getresponse/lib/get_response/contact.rb:145: warning: method redefined; discarding old name=
.............................................................................................

Finished in 0.091754s, 1057.1746 runs/s, 2147.0454 assertions/s.

98 runs, 198 assertions, 0 failures, 0 errors, 0 skips
```